### PR TITLE
Mise à jour de Microsoft.VisualStudio.SDK à 17.13.40008

### DIFF
--- a/BuildOnSave.Extension/BuildOnSave.Extension.csproj
+++ b/BuildOnSave.Extension/BuildOnSave.Extension.csproj
@@ -67,7 +67,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" NoWarn="NU1604" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.13.40008" ExcludeAssets="runtime" NoWarn="NU1604">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.1043-preview2" NoWarn="NU1604" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Mise à jour de Microsoft.VisualStudio.SDK à 17.13.40008

La référence au package `Microsoft.VisualStudio.SDK` a été mise à jour de la version `17.0.32112.339` à `17.13.40008`. Des éléments ont également été ajoutés pour spécifier les actifs inclus : `compile`, `build`, `native`, `contentfiles`, `analyzers` et `buildtransitive`.